### PR TITLE
Use RFC6761 compliant names in POD & tests

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -92,7 +92,7 @@ See below for cut-paste-y examples.
 
     #Use this method any time you want to update contact information,
     #not just when you set up a new account.
-    my $reg = $acme->register('mailto:who.am@i.tld', 'mailto:who@else.tld');
+    my $reg = $acme->register('mailto:me@example.com', 'mailto:who@example.com');
 
     $acme->accept_tos( $reg->uri(), $tos_url );
 

--- a/lib/Net/ACME.pm
+++ b/lib/Net/ACME.pm
@@ -94,7 +94,7 @@ See below for cut-paste-y examples.
 
     #Use this method any time you want to update contact information,
     #not just when you set up a new account.
-    my $reg = $acme->register('mailto:who.am@i.tld', 'mailto:who@else.tld');
+    my $reg = $acme->register('mailto:me@example.com', 'mailto:who@example.com');
 
     $acme->accept_tos( $reg->uri(), $tos_url );
 

--- a/t/Net-ACME.t
+++ b/t/Net-ACME.t
@@ -459,7 +459,7 @@ sub test_registration : Tests(2) {
         sub {
             my $acme = _get_acme();
 
-            my $reg = $acme->register('mailto:f@g.tld');
+            my $reg = $acme->register('mailto:f@g.test');
 
             my %methods = (
                 uri       => re(qr</reg/>),
@@ -504,7 +504,7 @@ sub test_registration : Tests(2) {
                     ignore(),
                     {
                         resource => 'new-reg',
-                        contact  => ['mailto:f@g.tld'],
+                        contact  => ['mailto:f@g.test'],
                     },
                 ],
             },


### PR DESCRIPTION
.tld isn't a reserved DNS domain, so it's conceivable it could be assigned at some point in the future.  I've changed the docs to use example.com (I shortened who.am@ to me@ as well, to make it more likely to fit on one line).  I changed the tests to use the .test TLD.  example.com and *.test will never be assigned to real organizations.

This pull request implements these changes - feel free to send it back to me if you have alternative ideas on how to fix this.

As an aside, whether you accept or reject my PR, I'm pretty excited to try out this module - it looks like it will be a really handy module for my web apps!  Thanks for providing this to the community!